### PR TITLE
[Feature] Explanation section with ollama

### DIFF
--- a/components/QuizForm.tsx
+++ b/components/QuizForm.tsx
@@ -57,9 +57,10 @@ const QuizForm: FC<Props> = ({
 
   const explainCorrectAnswer = async () => {
     try {
-      const prompt = `${question} These are the answers provided: ${options.map(
-        (option) => `${option.text}: ${option.isAnswer}`,
-      )}`;
+      console.log(options);
+      const prompt = `${question} Explain why these answers are correct: ${options
+        .filter((o) => o.isAnswer == true)
+        .map((o) => o.text)}`;
       console.log(prompt);
 
       const response = await fetch("http://localhost:11434/api/generate", {

--- a/components/QuizForm.tsx
+++ b/components/QuizForm.tsx
@@ -274,6 +274,7 @@ const QuizForm: FC<Props> = ({
           disabled={currentQuestionIndex < lastIndex}
           onClick={() => {
             setShowCorrectAnswer(false);
+            setExplanation(null);
             setSavedAnswers((prev) => ({
               ...prev,
               [currentQuestionIndex]: watchInput,

--- a/components/QuizForm.tsx
+++ b/components/QuizForm.tsx
@@ -80,7 +80,6 @@ const QuizForm: FC<Props> = ({
       const responseData = await response.json();
 
       if (responseData && "response" in responseData) {
-        console.log("Response:", responseData);
         setExplanation(responseData.response);
       } else {
         console.error("Response does not contain explanation:", responseData);

--- a/components/QuizForm.tsx
+++ b/components/QuizForm.tsx
@@ -57,11 +57,9 @@ const QuizForm: FC<Props> = ({
 
   const explainCorrectAnswer = async () => {
     try {
-      console.log(options);
       const prompt = `${question} Explain why these answers are correct: ${options
         .filter((o) => o.isAnswer == true)
         .map((o) => o.text)}`;
-      console.log(prompt);
 
       const response = await fetch("http://localhost:11434/api/generate", {
         method: "POST",

--- a/components/QuizForm.tsx
+++ b/components/QuizForm.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from "react";
+import { type FC, useState, useEffect } from "react";
 import { useForm, FieldValues } from "react-hook-form";
 import { Question } from "./types";
 import Image from "next/image";
@@ -25,6 +25,7 @@ const QuizForm: FC<Props> = ({
   const { register, handleSubmit, reset, watch } = useForm();
   const [showCorrectAnswer, setShowCorrectAnswer] = useState<boolean>(false);
   const [isThinking, setIsThinking] = useState<boolean>(false);
+  const [ollamaAvailable, setOllamaAvailable] = useState<boolean>(false);
   const [explanation, setExplanation] = useState<string | null>(null);
   const [lastIndex, setLastIndex] = useState<number>(1);
   const [canGoBack, setCanGoBack] = useState<boolean>(false);
@@ -35,6 +36,21 @@ const QuizForm: FC<Props> = ({
     url: string;
     alt: string;
   } | null>(null);
+
+  useEffect(() => {
+    const checkOllamaStatus = async () => {
+      try {
+        const response = await fetch("http://localhost:11434");
+        if (response.ok) {
+          setOllamaAvailable(true);
+        }
+      } catch (error) {
+        console.error("Error checking server status:", error);
+      }
+    };
+
+    checkOllamaStatus();
+  }, []);
 
   const onSubmit = (data: FieldValues) => {
     setSavedAnswers((prev) => ({
@@ -251,20 +267,22 @@ const QuizForm: FC<Props> = ({
         >
           Reveal Answer
         </Button>
-        <Button
-          type="button"
-          intent="secondary"
-          size="medium"
-          disabled={isThinking}
-          onClick={() => {
-            setShowCorrectAnswer(true);
-            setIsThinking(true);
-            explainCorrectAnswer();
-            reset();
-          }}
-        >
-          {isThinking ? "Thinking..." : "Explain"}
-        </Button>
+        {ollamaAvailable && (
+          <Button
+            type="button"
+            intent="secondary"
+            size="medium"
+            disabled={isThinking}
+            onClick={() => {
+              setShowCorrectAnswer(true);
+              setIsThinking(true);
+              explainCorrectAnswer();
+              reset();
+            }}
+          >
+            {isThinking ? "Thinking..." : "Explain"}
+          </Button>
+        )}
         <Button
           type="button"
           intent="primary"


### PR DESCRIPTION
[Fixes #17](https://github.com/Ditectrev/Practice-Exams-Platform/issues/17)

<img width="689" alt="Screenshot 2024-05-12 at 18 44 28" src="https://github.com/Ditectrev/Practice-Exams-Platform/assets/23294963/2934bf3a-736a-4cea-9338-65354a906b32">

_wip layout_

## Summary
- Adds a button that prompts a locally running [ollama](https://ollama.com/) server to explain the correct answers to the question.
- The prompt consists of the question and answers, giving as much context as possible for the LLM.

## CORS
When the app is deployed to production, your locally running ollama should be started with this option:
`OLLAMA_ORIGINS="https://education.ditectrev.com" ollama serve`

## Todo
- [x] Check whether ollama is running
- [x] Fine-tune prompt
- [ ] ollama options (currently `mistral` is the hard-coded model)
- [x] Improve layout of buttons and answers
- [x] Remove debug code
- [ ] Tests